### PR TITLE
Binary search in clojure

### DIFF
--- a/clojure/algorithms/binary_search.clj
+++ b/clojure/algorithms/binary_search.clj
@@ -1,0 +1,11 @@
+(defn binary-search [number-list search-target]
+  (loop [lower-boundary-index 0
+        upper-boundary-index (dec (count number-list))]
+    (if (> lower-boundary-index upper-boundary-index) 
+      nil
+      (let [middle-index (quot (+ lower-boundary-index upper-boundary-index) 2)
+            middle-value (nth number-list middle-index)]
+       (cond
+        (< middle-value search-target) (recur (inc middle-index) upper-boundary-index)
+        (> middle-value search-target) (recur lower-boundary-index (dec middle-index))
+        (= middle-value search-target) middle-index)))))


### PR DESCRIPTION
binary search in clojure

takes two arguments: a sorted list of numbers and a target number
returns: the index of the target number in the sorted list of numbers