### PR TITLE
Fix typo in contributing document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,13 @@ Install Git:
 ###### After you are done installing Git on your computer:
 
 1. Fork this repository on Github.
-2. Clone it onto your computer by opening terminal and running the command $ git clone https://github.com/{your username}/Data-Structures-And-Algorithms-Hacktoberfest18.git
-3. Use the actual name of the repository to change into that directory (eg. *$ cd repository*) and create and switch to a new branch by the following command: $ git checkout -b new-branch
-4. After modifying existing files or adding new files to the project, add them locally to your repository using $ git add -A command where A is the file
-5. Add a short message about what you contributed for with the git commit command. For eg. $ git commit -m "Fixed documentation typos"
-6. Now use the command $ git push --set-upstream origin new-branch to push the changes to the current branch of your forked repository
-7. Now you can create a Pull Request with the chosen branch as new-branch
+2. Clone it onto your computer by opening terminal and running the command
+```
+git clone https://github.com/{your username}/Data-Structures-And-Algorithms-Hacktoberfest18.git
+```
+3. Use the actual name of the repository to change into that directory (eg. `cd repository`) and create and switch to a new branch by the following command:
+`git checkout -b new-branch`
+4. After modifying existing files or adding new files to the project, add them locally to your repository using `git add -A` command where A is the file
+5. Add a short message about what you contributed for with the git commit command. E.g. `git commit -m "Fixed documentation typos"`
+6. Now use the command `git push -u origin new-branch` to push the changes to the current branch of your forked repository
+7. Now you can create a Pull Request with the chosen branch as new-branch by going to your repo page on Github.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Install Git:
 1. Fork this repository on Github.
 2. Clone it onto your computer by opening terminal and running the command $ git clone https://github.com/{your username}/Data-Structures-And-Algorithms-Hacktoberfest18.git
 3. Use the actual name of the repository to change into that directory (eg. *$ cd repository*) and create and switch to a new branch by the following command: $ git checkout -b new-branch
-4. After modifying existing files or adding new files to the project, add them locally to your repository using $ gid add -A command where A is the file
+4. After modifying existing files or adding new files to the project, add them locally to your repository using $ git add -A command where A is the file
 5. Add a short message about what you contributed for with the git commit command. For eg. $ git commit -m "Fixed documentation typos"
 6. Now use the command $ git push --set-upstream origin new-branch to push the changes to the current branch of your forked repository
 7. Now you can create a Pull Request with the chosen branch as new-branch


### PR DESCRIPTION
Changes:

1.  On bullet-point 6, changed `--set-upstream` to the shorthand `-u` since we use `-b` on point 3
2. On bullet-point 7, added further instruction as to where to begin creating new pull request.
3. use \<code> tags (<code>`</code>  for short in markdown) to improve readability of git/terminal commands